### PR TITLE
[JUP-418]: publish to npm registry at npmjs.com

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,9 @@
 nodeLinker: pnp
 
+npmPublishAccess: public
+
 npmScopes:
-  rhinofi:
+  rhino.fi:
     npmAlwaysAuth: true
-    npmPublishRegistry: "https://npm.pkg.github.com"
-    npmRegistryServer: "https://npm.pkg.github.com"
-    npmAuthToken: "${GITHUB_PACKAGE_REGISTRY_ACCESS_TOKEN}"
+    npmAuthToken: ${NPM_ACCESS_TOKEN-}
+    npmPublishRegistry: https://registry.npmjs.org

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,10 @@
+# Publishing to our npm registry
+
+Things to check before publishing:
+- any newly added source files which are to be included in the package have been added to "files" list in `package.json`
+- `version` in `package.json` has been updated appropriately
+
+From nix shell:
+```sh
+npm-publish
+```

--- a/README.md
+++ b/README.md
@@ -51,16 +51,3 @@ any of the arguments passed to those loggers is a function, it will be called to
 get the value to be logged, however this will only happen if given logger is
 enabled. This way we can avoid paying for pre-processing if the value would not
 have been logged anyway.
-
-
-# Publishing to our npm registry
-
-Things to check before publishing:
-- any newly added source files which are to be included in the package have been added to "files" list in `package.json`
-- `version` in `package.json` has been updated appropriately
-- you have a github token in your ~/.netrc file with permissions to publish the package
-
-From nix shell:
-```sh
-npm-publish
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@rhinofi/logger",
-  "version": "test",
+  "name": "@rhino.fi/logger",
+  "version": "1.1.2",
   "description": "a thin wrapper around debug module",
   "main": "index.js",
   "repository": "git://github.com/rhinofi/logger.git",
@@ -11,9 +11,6 @@
   },
   "devDependencies": {
     "bson": "^1.1.5"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
   },
   "files": [
     "index.js",

--- a/shell.nix
+++ b/shell.nix
@@ -1,18 +1,9 @@
 let
   pkgs = import ./nix/pkgs.nix {};
-  npm-publish = pkgs.utils.writeBashBin "npm-publish" ''
-    set -ueo pipefail
-
-    # Using yarn provided by nix shell.
-    GITHUB_PACKAGE_REGISTRY_ACCESS_TOKEN=$(${pkgs.lib.getExe pkgs.github-token-from-netrc}) \
-      yarn npm publish "''${@}"
-  '';
 in
   pkgs.mkShell {
     inputsFrom = [pkgs.dev-shell-with-node-yarn-berry];
     packages = with pkgs; [
       npm-publish
-      dprint-with-config
-      eslint-with-config
     ];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@rhinofi/logger@workspace:.":
+"@rhino.fi/logger@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@rhinofi/logger@workspace:."
+  resolution: "@rhino.fi/logger@workspace:."
   dependencies:
     bson: ^1.1.5
     debug: ^4.3.2


### PR DESCRIPTION
instead of github
as explained here: https://rhinofi.slack.com/archives/C03AAUGFC2X/p1663159393216229