### PR TITLE
[devops] load github token via GCP secret manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,15 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command
 
+    - id: secrets
+      uses: google-github-actions/get-secretmanager-secrets@v1
+      with:
+        secrets: github_token:dvf-shared/GITHUB_TOKEN_ALL_REPOS_READ
+
     - name: Bootstrap nix config
-      run: echo ${{ secrets.CI_GITHUB_TOKEN }} | ./nix/netrc-create.sh
+      env:
+        GITHUB_TOKEN: '${{ steps.secrets.outputs.github_token }}'
+      run: ./nix/netrc-create.sh
 
     - name: Run pr-step
       run: nix run --impure -f nix/pkgs.nix ci.pr-step

--- a/nix/netrc-create.sh
+++ b/nix/netrc-create.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -ueo pipefail
 
-github_token=''${GITHUB_TOKEN-}
+github_token=${GITHUB_TOKEN-}
 
 if [[ -z $github_token ]]; then
-  read -s github_token
+  while read -r github_token; do
+    break
+  done
 fi
 
 github_user=${1:-dvf-ci}


### PR DESCRIPTION
same as: https://github.com/rhinofi/dvf-utils/pull/189